### PR TITLE
feat: make create_db scripts configurable via env variables

### DIFF
--- a/cmd/create_db/create_dbfile
+++ b/cmd/create_db/create_dbfile
@@ -1,1 +1,6 @@
-sqlite3 /home/ubuntu/data/keysdb.sqlite3 < schema.sql
+#!/bin/bash
+
+: "${SQLITE_DSN:=/home/ubuntu/data/keysdb.sqlite3}"
+: "${SCHEMA_FILE:=./schema.sql}"
+
+sqlite3 "$SQLITE_DSN" < "$SCHEMA_FILE"

--- a/cmd/create_db/gen
+++ b/cmd/create_db/gen
@@ -1,1 +1,6 @@
-jet -source=sqlite -dsn="/home/ubuntu/data/keysdb.sqlite3" -schema=main -path=../../internal/db/.gen
+#!/bin/bash
+
+: "${SQLITE_DSN:=/home/ubuntu/data/keysdb.sqlite3}"
+: "${DEST_PATH:=../../internal/db/.gen}"
+
+jet -source=sqlite -dsn="$SQLITE_DSN" -schema=main -path="$DEST_PATH"


### PR DESCRIPTION
I wanted to store my database in a different path so I made this changes, defaults are still the same for compatibility with current setup