### PR TITLE
feat: override default or test config instead of replacing them

### DIFF
--- a/internal/config/cli.go
+++ b/internal/config/cli.go
@@ -100,21 +100,20 @@ func loadConfig(flags flags) (*ConfigResult, error) {
 	var err error
 	var source string
 
-	switch {
-	case *flags.configPath != "":
-		cfg, err = LoadConfig(*flags.configPath)
+	if *flags.useTest {
+		cfg = NewTestConfig()
+		source = "built-in test configuration"
+	} else {
+		cfg = NewConfig()
+		source = "default production configuration"
+	}
+
+	if *flags.configPath != "" {
+		err = cfg.LoadConfig(*flags.configPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load config: %v", err)
 		}
 		source = fmt.Sprintf("custom config file: %s", *flags.configPath)
-
-	case *flags.useTest:
-		cfg = TestConfig()
-		source = "built-in test configuration"
-
-	default:
-		cfg = DefaultConfig()
-		source = "default production configuration"
 	}
 
 	return &ConfigResult{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,23 +47,8 @@ type Config struct {
 	} `json:"backup"`
 }
 
-// LoadConfig loads configuration from a JSON file
-func LoadConfig(path string) (*Config, error) {
-	file, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("error reading config file: %v", err)
-	}
-
-	var config Config
-	if err := json.Unmarshal(file, &config); err != nil {
-		return nil, fmt.Errorf("error parsing config file: %v", err)
-	}
-
-	return &config, nil
-}
-
 // DefaultConfig returns the default production configuration
-func DefaultConfig() *Config {
+func NewConfig() *Config {
 	config := &Config{}
 
 	// Server defaults
@@ -102,7 +87,7 @@ func DefaultConfig() *Config {
 }
 
 // TestConfig returns a configuration suitable for testing
-func TestConfig() *Config {
+func NewTestConfig() *Config {
 	config := &Config{}
 
 	// Server test settings
@@ -129,4 +114,18 @@ func TestConfig() *Config {
 	config.Backup.Enabled = false
 
 	return config
+}
+
+// LoadConfig loads configuration from a JSON file
+func (config *Config) LoadConfig(path string) error {
+	file, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("error reading config file: %v", err)
+	}
+
+	if err := json.Unmarshal(file, &config); err != nil {
+		return fmt.Errorf("error parsing config file: %v", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
I got this error on first run:
```
2024/12/29 19:24:28 Starting server with custom config file: ./.config.json
2024/12/29 19:24:28 No existing host key found, generating new one...
panic: non-positive interval for NewTicker

goroutine 20 [running]:
time.NewTicker(0x0?)
        /snap/go/10748/src/time/tick.go:38 +0xbb
keypub/internal/ratelimit.(*RateLimiter).cleanupLoop(0xc0001cecc0)
        /home/salar/w/keypub/internal/ratelimit/ratelimit.go:60 +0x37
created by keypub/internal/ratelimit.NewRateLimiter in goroutine 1
        /home/salar/w/keypub/internal/ratelimit/ratelimit.go:48 +0xdb
```
It was because when you provide a config file, it replaces all values and not provided values aren't remaining as default.
I've made changes to override config and keep not provided values default, also the same in test config.