### PR TITLE
feat: support passphrase protected host keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.nogit.*
 .*
 keysdb.sqlite3
+keysdb.sqlite3-shm
+keysdb.sqlite3-wal

--- a/cmd/ssh_server/hostkey.go
+++ b/cmd/ssh_server/hostkey.go
@@ -13,7 +13,7 @@ import (
 	gossh "golang.org/x/crypto/ssh"
 )
 
-func loadHostKey(path string) (ssh.Signer, error) {
+func loadHostKey(path, passphrase string) (ssh.Signer, error) {
 	keyBytes, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -46,7 +46,12 @@ func loadHostKey(path string) (ssh.Signer, error) {
 	}
 
 	log.Printf("Loading existing host key...")
-	signer, err := gossh.ParsePrivateKey(keyBytes)
+	var signer ssh.Signer
+	if passphrase == "" {
+		signer, err = gossh.ParsePrivateKey(keyBytes)
+	} else {
+		signer, err = gossh.ParsePrivateKeyWithPassphrase(keyBytes, []byte(passphrase))
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse host key: %w", err)
 	}

--- a/cmd/ssh_server/main.go
+++ b/cmd/ssh_server/main.go
@@ -38,7 +38,7 @@ func main() {
 	defer ratelimit.Stop()
 
 	// initialize server
-	hostKey, err := loadHostKey(cfg.Server.HostKey)
+	hostKey, err := loadHostKey(cfg.Server.HostKey, cfg.Server.HostKeyPassphrase)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/config/cli.go
+++ b/internal/config/cli.go
@@ -100,21 +100,20 @@ func loadConfig(flags flags) (*ConfigResult, error) {
 	var err error
 	var source string
 
-	switch {
-	case *flags.configPath != "":
-		cfg, err = LoadConfig(*flags.configPath)
+	if *flags.useTest {
+		cfg = NewTestConfig()
+		source = "built-in test configuration"
+	} else {
+		cfg = NewConfig()
+		source = "default production configuration"
+	}
+
+	if *flags.configPath != "" {
+		err = cfg.LoadConfig(*flags.configPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load config: %v", err)
 		}
 		source = fmt.Sprintf("custom config file: %s", *flags.configPath)
-
-	case *flags.useTest:
-		cfg = TestConfig()
-		source = "built-in test configuration"
-
-	default:
-		cfg = DefaultConfig()
-		source = "default production configuration"
 	}
 
 	return &ConfigResult{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,23 +47,8 @@ type Config struct {
 	} `json:"backup"`
 }
 
-// LoadConfig loads configuration from a JSON file
-func LoadConfig(path string) (*Config, error) {
-	file, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("error reading config file: %v", err)
-	}
-
-	var config Config
-	if err := json.Unmarshal(file, &config); err != nil {
-		return nil, fmt.Errorf("error parsing config file: %v", err)
-	}
-
-	return &config, nil
-}
-
 // DefaultConfig returns the default production configuration
-func DefaultConfig() *Config {
+func NewConfig() *Config {
 	config := &Config{}
 
 	// Server defaults
@@ -102,7 +87,7 @@ func DefaultConfig() *Config {
 }
 
 // TestConfig returns a configuration suitable for testing
-func TestConfig() *Config {
+func NewTestConfig() *Config {
 	config := &Config{}
 
 	// Server test settings
@@ -129,4 +114,18 @@ func TestConfig() *Config {
 	config.Backup.Enabled = false
 
 	return config
+}
+
+// LoadConfig loads configuration from a JSON file
+func (config *Config) LoadConfig(path string) error {
+	file, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("error reading config file: %v", err)
+	}
+
+	if err := json.Unmarshal(file, &config); err != nil {
+		return fmt.Errorf("error parsing config file: %v", err)
+	}
+
+	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,8 +9,9 @@ import (
 
 type Config struct {
 	Server struct {
-		Port    int    `json:"port"`
-		HostKey string `json:"host_key_path"`
+		Port              int    `json:"port"`
+		HostKey           string `json:"host_key_path"`
+		HostKeyPassphrase string `json:"host_key_passphrase"`
 	} `json:"server"`
 
 	Database struct {
@@ -54,6 +55,7 @@ func NewConfig() *Config {
 	// Server defaults
 	config.Server.Port = 22
 	config.Server.HostKey = "/home/ubuntu/.keys/.host"
+	config.Server.HostKeyPassphrase = ""
 
 	// Database defaults
 	config.Database.Path = "/home/ubuntu/data/keysdb.sqlite3"
@@ -93,6 +95,7 @@ func NewTestConfig() *Config {
 	// Server test settings
 	config.Server.Port = 2288
 	config.Server.HostKey = "/home/ubuntu/.keys/.host"
+	config.Server.HostKeyPassphrase = ""
 
 	// Database test settings
 	config.Database.Path = "/home/ubuntu/data_test/keysdb.sqlite3"


### PR DESCRIPTION
This PR contains #25

When I passed a passphrase protected key as host key I got `failed to parse host key: ssh: this private key is passphrase protected` error. I've made the change to make passphrase configurable and support protected keys.